### PR TITLE
Change access modifier of ResizableSheetCenter's window 

### DIFF
--- a/Sources/ResizableSheet/ResizableSheetCenter.swift
+++ b/Sources/ResizableSheet/ResizableSheetCenter.swift
@@ -9,7 +9,7 @@ public class ResizableSheetCenter {
         didSet { update() }
     }
 
-    private let window: OverlayWindow?
+    public let window: UIWindow?
     private let layer: UIHostingController<AnyView?>?
     private let previousKeyWindow: UIWindow?
 


### PR DESCRIPTION
In #9, `UIWindow`'s issue was reported.
To update user interface style, we have to update `overrideUserInterfaceStyle`, but now we cannot access `window` in ResizableSheetCenter.
So I updated the access level in this PR.